### PR TITLE
Add general requirements for missing packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ docker/mapdl/v212
 
 # temp testing
 tmp.out
+
+# Python virtual environment
+/venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# #############################################################################
+# requirements
+# #############################################################################
+grpcio-tools >= 1.39.0
+# https://github.com/grpc/grpc/tree/master/tools/distrib/python/grpcio_tools
+
+twine >= 3.4.2
+# https://github.com/pypa/twine/


### PR DESCRIPTION
- Add requirements.txt for grpcio-tools and twine. Cannot successfully run the tool through Python as in the example in the README without these two packages.
- Add venv to git ignore.