### PR TITLE
Fix module-name when proto filename starts with py

### DIFF
--- a/ansys/tools/protos_generator/generator.py
+++ b/ansys/tools/protos_generator/generator.py
@@ -230,7 +230,7 @@ def package_protos(protos_path, dist_dir, wheel=False):
     for filename in grpc_source_files:
         relative_path = filename.replace(grpc_source_path, '')
         module_name = '.'.join(re.split(r'\\|/', relative_path))
-        module_name = module_name.replace('.py', '')
+        module_name = module_name.rstrip('.py')
         module_name = module_name.strip('.')
         py_source[module_name] = open(filename).read()
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -81,6 +81,8 @@ def test_generate(tmpdir):
     from ansys.api.sample.v1 import sample_pb2
     assert hasattr(sample_pb2, 'SampleReply')
     assert hasattr(sample_pb2, 'SampleRequest')
+    from ansys.api.sample.v1 import sample_pb2_grpc
+    assert hasattr(sample_pb2_grpc, 'Sample')
 
     p = subprocess.Popen(f"{sys.executable} -m pip uninstall {name} -y",
                          stdout=subprocess.PIPE,


### PR DESCRIPTION
sample_pb2.py and sample_pb2_grpc.py are generated from a PROTO file pysample.proto. This is a problem as sample_pb2_grpc cannot be imported as it expects pysample_pb2.